### PR TITLE
Make readable the tag_ids too

### DIFF
--- a/lib/twitch/stream.rb
+++ b/lib/twitch/stream.rb
@@ -31,6 +31,8 @@ module Twitch
     attr_reader :language
     # URL of the latest thumbnail image for the broadcast.
     attr_reader :thumbnail_url
+    # Ids of tags on the live stream
+    attr_reader :tag_ids
 
     def initialize(attributes = {})
       attributes.each do |key, value|


### PR DESCRIPTION
Twitch API is also giving the tag_ids on the response. Let's make this attribute readable too :)