### PR TITLE
Large update from fork

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -60,8 +60,8 @@ rspec_task:
       image: ruby:2.7
   <<: *bundle_cache
 
-  # environment:
-  #   CODECOV_TOKEN: ENCRYPTED[...]
+  environment:
+    CODECOV_TOKEN: ENCRYPTED[112171f047148669318b81ebaf5210bd7bc59a7c9e1179e1aff636a206f07269f5698eb06f31f8b07450570ae13a66a6]
 
   test_script: bundle exec rspec --format=json --out=rspec.json
 

--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -54,7 +54,6 @@ rspec_task:
 
   container:
     matrix:
-      image: ruby:2.4
       image: ruby:2.5
       image: ruby:2.6
       image: ruby:2.7

--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -1,0 +1,78 @@
+bundle_cache: &bundle_cache
+  bundle_cache:
+    folder: /usr/local/bundle
+    fingerprint_script:
+      - echo $CIRRUS_OS
+      - ruby -v
+      - cat Gemfile
+      - cat *.gemspec
+  install_script:
+    - gem install bundler
+    - bundle update
+
+# remark_task:
+#   container:
+#     image: node
+#   node_modules_cache:
+#     folder: node_modules
+#     fingerprint_script:
+#       - echo $CIRRUS_OS
+#       - node -v
+#       - cat package.json
+#   install_script: npm install
+#
+#   lint_script: npm run remark
+#
+#   only_if: ($CIRRUS_BRANCH == 'master') ||
+#     changesInclude(
+#       '.cirrus.yml', '.gitignore', 'package.json', '.remarkrc.yaml', '**.md'
+#     )
+
+rubocop_task:
+  container:
+    image: ruby:latest
+  <<: *bundle_cache
+
+  lint_script: bundle exec rubocop --format=json --out=rubocop.json
+
+  always:
+    rubocop_artifacts:
+      path: rubocop.json
+      type: text/json
+      format: rubocop
+
+  only_if: ($CIRRUS_BRANCH == 'master') ||
+    changesInclude(
+      '.cirrus.yml', '.gitignore', 'Gemfile', 'Rakefile', '.rubocop.yml', '*.gemspec',
+      '**.rb', '**.ru'
+    )
+
+rspec_task:
+  depends_on:
+    # - remark
+    - rubocop
+
+  container:
+    matrix:
+      image: ruby:2.4
+      image: ruby:2.5
+      image: ruby:2.6
+      image: ruby:2.7
+  <<: *bundle_cache
+
+  # environment:
+  #   CODECOV_TOKEN: ENCRYPTED[...]
+
+  test_script: bundle exec rspec --format=json --out=rspec.json
+
+  always:
+    rspec_artifacts:
+      path: rspec.json
+      type: text/json
+      format: rspec
+
+  only_if: ($CIRRUS_BRANCH == 'master') ||
+    changesInclude(
+      '.cirrus.yml', '.gitignore', 'Gemfile', 'Rakefile', '.rspec', '*.gemspec', 'lib/**',
+      'spec/**'
+    )

--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -10,23 +10,23 @@ bundle_cache: &bundle_cache
     - gem install bundler
     - bundle update
 
-# remark_task:
-#   container:
-#     image: node
-#   node_modules_cache:
-#     folder: node_modules
-#     fingerprint_script:
-#       - echo $CIRRUS_OS
-#       - node -v
-#       - cat package.json
-#   install_script: npm install
-#
-#   lint_script: npm run remark
-#
-#   only_if: ($CIRRUS_BRANCH == 'master') ||
-#     changesInclude(
-#       '.cirrus.yml', '.gitignore', 'package.json', '.remarkrc.yaml', '**.md'
-#     )
+remark_task:
+  container:
+    image: node
+  node_modules_cache:
+    folder: node_modules
+    fingerprint_script:
+      - echo $CIRRUS_OS
+      - node -v
+      - cat package.json
+  install_script: npm install
+
+  lint_script: npm run remark
+
+  only_if: ($CIRRUS_BRANCH == 'master') ||
+    changesInclude(
+      '.cirrus.yml', '.gitignore', 'package.json', '.remarkrc.yaml', '**.md'
+    )
 
 rubocop_task:
   container:
@@ -49,7 +49,7 @@ rubocop_task:
 
 rspec_task:
   depends_on:
-    # - remark
+    - remark
     - rubocop
 
   container:

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,4 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 Gemfile.lock
 .ruby-version
 .ruby-gemset
+package-lock.json
+/node_modules/

--- a/.remarkrc.yaml
+++ b/.remarkrc.yaml
@@ -1,0 +1,4 @@
+plugins:
+  - remark-preset-lint-recommended
+  - - remark-lint-code-block-style
+    - fenced

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
+AllCops:
+  NewCops: enable
+
+Layout/LineLength:
+  Max: 100
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 Layout/LineLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-sudo: false
 language: ruby
 rvm:
-  - 2.3.8
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-before_install: gem install bundler -v 2.1.4
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
+before_install: gem install bundler
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 2.4
-  - 2.5
-  - 2.6
-  - 2.7
-before_install: gem install bundler
-cache: bundler

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ This library is a Ruby implementation of the [Twitch Helix API](https://dev.twit
 The goal is to provide access for the newest supported APIs provided by Twitch, while keeping extensiblity for their future expansion. These are still in development, as is this library which should remain in pace with changes made.
 
 Guaranteed supported APIs include:
-* Helix REST (full rolling support)
-* Helix Webhooks (coming soon)
+*   Helix REST (full rolling support)
+*   Helix Webhooks (coming soon)
 
 The future may bring:
-* Authentication
-* PubSub
-* TMI/chat
+*   Authentication
+*   PubSub
+*   TMI/chat
 
 These will not be considered:
-* Twitch kraken API
-* [Twitch GraphQL API](https://github.com/mauricew/twitch-graphql-api)
+*   Twitch kraken API
+*   [Twitch GraphQL API](https://github.com/mauricew/twitch-graphql-api)
 
 ## Installation
 Ruby 2.1 or later compatibility is guaranteed, however the target is 2.0 and above.
@@ -35,11 +35,15 @@ gem 'twitch-api', :git => 'https://github.com/mauricew/ruby-twitch-api'
 
 And then execute:
 
-    $ bundle
+```sh
+$ bundle
+```
 
 Or install it yourself as:
 
-    $ gem install twitch-api
+```sh
+$ gem install twitch-api
+```
 
 ## Usage
 A client must be initialized with your client ID or bearer access token.
@@ -51,10 +55,10 @@ client = Twitch::Client.new(access_token: "YOUR_ACCESS_TOKEN")
 Because data may change for certain endpoints, there is also a keyword parameter called `with_raw` that returns the raw response for any request called.
 
 Retrieval methods take in a hash equal to the parameters of the API endpoint, and return a response object containing the data and other associated request information:
-* **data** is the data you would get back. Even if it's an array of one object, it remains the same as what comes from the API.
-* **rate_limit** and associated fields contain API request limit information. Clip creation counts for a second limit (duration currently unknown).
-* **pagination** is a hash that appears when data can be traversed, and contains one member (*cursor*) which lets you pagniate through certain requests.
-* **raw** is the raw HTTP response data when `with_raw` is true in the client.
+*   **data** is the data you would get back. Even if it's an array of one object, it remains the same as what comes from the API.
+*   **rate_limit** and associated fields contain API request limit information. Clip creation counts for a second limit (duration currently unknown).
+*   **pagination** is a hash that appears when data can be traversed, and contains one member (*cursor*) which lets you paginate through certain requests.
+*   **raw** is the raw HTTP response data when `with_raw` is true in the client.
 ```
 # Get top live streams
 client.get_streams.data
@@ -79,4 +83,4 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/mauricew/ruby-twitch-api.
+Bug reports and pull requests are welcome on [GitHub](https://github.com/mauricew/ruby-twitch-api).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Gem](https://img.shields.io/gem/v/twitch-api.svg)](https://rubygems.org/gems/twitch-api)
 [![Downloads](https://img.shields.io/gem/dt/twitch-api.svg)](https://rubygems.org/gems/twitch-api)
 [![Travis](https://img.shields.io/travis/mauricew/ruby-twitch-api.svg)](https://travis-ci.org/mauricew/ruby-twitch-api)
-[![License](https://img.shields.io/github/license/mauricew/ruby-twitch-api.svg)]()
+[![License](https://img.shields.io/github/license/mauricew/ruby-twitch-api.svg)](LICENSE.txt)
 # Ruby Twitch API
 
 This library is a Ruby implementation of the [Twitch Helix API](https://dev.twitch.tv/docs/api).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This library is a Ruby implementation of the [Twitch Helix API](https://dev.twitch.tv/docs/api).
 
-The goal is to provide access for the newest supported APIs provided by Twitch, while keeping extensiblity for their future expansion. These are still in development, as is this library which should remain in pace with changes made.
+The goal is to provide access for the newest supported APIs provided by Twitch, while keeping extensibility for their future expansion. These are still in development, as is this library which should remain in pace with changes made.
 
 Guaranteed supported APIs include:
 *   Helix REST (full rolling support)
@@ -70,7 +70,7 @@ client.get_games({name: ["Heroes of the Storm", "Super Mario Odyssey"]}).data
 ```
 
 ### Error handling
-An *ApiError* is raised whenever an HTTP error response is returned.
+An `ApiError` is raised whenever an HTTP error response is returned.
 Rescue it to access the body of the response, which should include an error message.
 
 ## Development

--- a/lib/twitch-api.rb
+++ b/lib/twitch-api.rb
@@ -2,6 +2,3 @@
 
 require_relative 'twitch/version'
 require_relative 'twitch/client'
-
-module Twitch
-end

--- a/lib/twitch/api_error.rb
+++ b/lib/twitch/api_error.rb
@@ -12,8 +12,7 @@ module Twitch
       @status_code = status_code
       @body = body
 
-      msg = "The server returned error #{status_code}"
-      super(msg)
+      super "The server returned error #{status_code}"
     end
   end
 end

--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -48,15 +48,15 @@ module Twitch
     # - with_raw [Boolean] Whether to include raw HTTP response
     # Intended for testing/checking API results
     def initialize(client_id: nil, access_token: nil, with_raw: false)
-      if client_id.nil? && access_token.nil?
+      unless client_id || access_token
         raise 'An identifier token (client ID or bearer token) is required'
       end
 
       warn TOKENS_CONFLICT_WARNING if client_id && access_token
 
-      CONNECTION.headers['Client-ID'] = client_id unless client_id.nil?
+      CONNECTION.headers['Client-ID'] = client_id if client_id
 
-      unless access_token.nil?
+      if access_token
         access_token = access_token.gsub(/^Bearer /, '')
         CONNECTION.headers['Authorization'] = "Bearer #{access_token}"
       end
@@ -65,89 +65,79 @@ module Twitch
     end
 
     def create_clip(options = {})
-      Response.new(Clip, post('clips', options))
+      initialize_response Clip, post('clips', options)
     end
 
     def create_entitlement_grant_url(options = {})
-      Response.new(EntitlementGrantUrl, post('entitlements/upload', options))
+      initialize_response EntitlementGrantUrl, post('entitlements/upload', options)
     end
 
     def create_stream_marker(options = {})
-      Response.new(StreamMarker, post('streams/markers', options))
+      initialize_response StreamMarker, post('streams/markers', options)
     end
 
     def get_clips(options = {})
-      Response.new(Clip, get('clips', options))
+      initialize_response Clip, get('clips', options)
     end
 
     def get_bits_leaderboard(options = {})
-      Response.new(BitsLeader, get('bits/leaderboard', options))
+      initialize_response BitsLeader, get('bits/leaderboard', options)
     end
 
     def get_games(options = {})
-      Response.new(Game, get('games', options))
+      initialize_response Game, get('games', options)
     end
 
     def get_top_games(options = {})
-      Response.new(Game, get('games/top', options))
+      initialize_response Game, get('games/top', options)
     end
 
     def get_game_analytics(options = {})
-      Response.new(GameAnalytic, get('analytics/games', options))
+      initialize_response GameAnalytic, get('analytics/games', options)
     end
 
     def get_stream_markers(options = {})
-      Response.new(StreamMarkerResponse, get('streams/markers', options))
+      initialize_response StreamMarkerResponse, get('streams/markers', options)
     end
 
     def get_streams(options = {})
-      Response.new(Stream, get('streams', options))
+      initialize_response Stream, get('streams', options)
     end
 
     def get_streams_metadata(options = {})
-      Response.new(StreamMetadata, get('streams/metadata', options))
+      initialize_response StreamMetadata, get('streams/metadata', options)
     end
 
     def get_users_follows(options = {})
-      Response.new(UserFollow, get('users/follows', options))
+      initialize_response UserFollow, get('users/follows', options)
     end
 
     def get_users(options = {})
-      Response.new(User, get('users', options))
+      initialize_response User, get('users', options)
     end
 
     def update_user(options = {})
-      Response.new(User, put('users', options))
+      initialize_response User, put('users', options)
     end
 
     def get_videos(options = {})
-      Response.new(Video, get('videos', options))
+      initialize_response Video, get('videos', options)
     end
 
     private
 
-    def get(resource, params)
-      http_res = CONNECTION.get(resource, params)
-      finish(http_res)
+    def initialize_response(data_class, http_response)
+      Response.new(data_class, http_response: http_response, with_raw: @with_raw)
     end
 
-    def post(resource, params)
-      http_res = CONNECTION.post(resource, params)
-      finish(http_res)
-    end
+    %w[get post put].each do |http_method|
+      define_method http_method do |resource, params|
+        http_response = CONNECTION.public_send http_method, resource, params
 
-    def put(resource, params)
-      http_res = CONNECTION.put(resource, params)
-      finish(http_res)
-    end
+        raise ApiError.new(http_response.status, http_response.body) unless http_response.success?
 
-    def finish(http_res)
-      raise ApiError.new(http_res.status, http_res.body) unless http_res.success?
-
-      {
-        http_res: http_res,
-        with_raw: @with_raw
-      }
+        http_response
+      end
     end
   end
 end

--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -57,7 +57,6 @@ module Twitch
       @conn = Faraday.new(API_ENDPOINT, { headers: headers }) do |faraday|
         faraday.request :json
         faraday.response :json
-        faraday.adapter Faraday.default_adapter
       end
 
       @with_raw = with_raw

--- a/lib/twitch/clip.rb
+++ b/lib/twitch/clip.rb
@@ -38,9 +38,9 @@ module Twitch
     def initialize(attributes = {})
       attributes.each do |key, value|
         if DATE_ATTRIBUTES.include?(key.to_sym)
-          instance_variable_set("@#{key}", Time.parse(value))
+          instance_variable_set "@#{key}", Time.parse(value)
         else
-          instance_variable_set("@#{key}", value)
+          instance_variable_set "@#{key}", value
         end
       end
     end

--- a/lib/twitch/game_analytic.rb
+++ b/lib/twitch/game_analytic.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Twitch
+  # Data object for `/analytics/games` requests
   class GameAnalytic
     # ID of the game requested.
     attr_reader :game_id

--- a/lib/twitch/response.rb
+++ b/lib/twitch/response.rb
@@ -33,12 +33,12 @@ module Twitch
     # The HTTP raw response
     attr_reader :raw
 
-    def initialize(data_class, res)
-      @http_res = res[:http_res]
-      @raw = @http_res if res[:with_raw]
-      body = @http_res.body
+    def initialize(data_class, http_response:, with_raw:)
+      @http_response = http_response
+      @raw = @http_response if with_raw
+      body = @http_response.body
 
-      @data = body['data'].map { |d| data_class.new(d) }
+      @data = body['data'].map { |data_element| data_class.new(data_element) }
 
       parse_rate_limits
 
@@ -60,7 +60,7 @@ module Twitch
 
     def rate_limit_headers
       @rate_limit_headers ||=
-        @http_res.headers
+        @http_response.headers
           .select { |key, _value| key.to_s.downcase.match(/^ratelimit/) }
           .map { |key, value| [key.gsub('ratelimit-', '').to_sym, value] }
           .to_h

--- a/lib/twitch/response.rb
+++ b/lib/twitch/response.rb
@@ -62,8 +62,7 @@ module Twitch
       @rate_limit_headers ||=
         @http_response.headers
           .select { |key, _value| key.to_s.downcase.match(/^ratelimit/) }
-          .map { |key, value| [key.gsub('ratelimit-', '').to_sym, value] }
-          .to_h
+          .transform_keys { |key| key.gsub('ratelimit-', '').to_sym }
     end
   end
 end

--- a/lib/twitch/stream.rb
+++ b/lib/twitch/stream.rb
@@ -35,9 +35,9 @@ module Twitch
     def initialize(attributes = {})
       attributes.each do |key, value|
         if DATE_ATTRIBUTES.include?(key.to_sym)
-          instance_variable_set("@#{key}", Time.parse(value))
+          instance_variable_set "@#{key}", Time.parse(value)
         else
-          instance_variable_set("@#{key}", value)
+          instance_variable_set "@#{key}", value
         end
       end
     end

--- a/lib/twitch/stream_marker.rb
+++ b/lib/twitch/stream_marker.rb
@@ -26,9 +26,7 @@ module Twitch
 
   # The response envelope for the "Get Stream Markers" endpoint.
   class StreamMarkerResponse
-    attr_reader :user_id
-    attr_reader :user_name
-    attr_reader :videos
+    attr_reader :user_id, :user_name, :videos
 
     def initialize(attributes = {})
       @user_id = attributes['user_id']
@@ -40,8 +38,7 @@ module Twitch
 
   # A video with a list of markers.
   class VideoStreamMarkers
-    attr_reader :video_id
-    attr_reader :markers
+    attr_reader :video_id, :markers
 
     def initialize(attributes = {})
       @video_id = attributes['video_id']

--- a/lib/twitch/stream_marker.rb
+++ b/lib/twitch/stream_marker.rb
@@ -31,8 +31,7 @@ module Twitch
     def initialize(attributes = {})
       @user_id = attributes['user_id']
       @user_name = attributes['user_name']
-      @videos =
-        attributes['videos'].map { |video| VideoStreamMarkers.new(video) }
+      @videos = attributes['videos'].map { |video| VideoStreamMarkers.new(video) }
     end
   end
 

--- a/lib/twitch/stream_metadata.rb
+++ b/lib/twitch/stream_metadata.rb
@@ -17,18 +17,27 @@ module Twitch
     attr_reader :game_id
 
     def initialize(attributes = {})
-      @user_id = attributes['user_id']
-      @user_name = attributes['user_name']
-      @game_id = attributes['game_id']
+      @attributes = attributes
 
-      # Since more games can be supported in the future,
-      # this will ensure they will all be available.
-      attributes.each do |key, value|
-        unless instance_variables.include?("@#{key}".to_sym)
-          self.class.send(:attr_reader, key.to_sym)
-          instance_variable_set("@#{key}", value)
-        end
-      end
+      @user_id = @attributes['user_id']
+      @user_name = @attributes['user_name']
+      @game_id = @attributes['game_id']
+    end
+
+    # Since more games can be supported in the future,
+    # this will ensure they will all be available.
+    def method_missing(name, *args)
+      name = name.to_s
+
+      return super unless @attributes.key?(name)
+
+      @attributes[name]
+    end
+
+    def respond_to_missing?(name)
+      name = name.to_s
+
+      @attributes.key?(name) ? true : super
     end
   end
 end

--- a/lib/twitch/stream_metadata.rb
+++ b/lib/twitch/stream_metadata.rb
@@ -13,7 +13,7 @@ module Twitch
     attr_reader :user_id
     # Display name of the streaming user.
     attr_reader :user_name
-    # ID of the game being playead.
+    # ID of the game being played.
     attr_reader :game_id
 
     def initialize(attributes = {})

--- a/lib/twitch/user.rb
+++ b/lib/twitch/user.rb
@@ -27,7 +27,7 @@ module Twitch
 
     def initialize(attributes = {})
       attributes.each do |key, value|
-        instance_variable_set("@#{key}", value)
+        instance_variable_set "@#{key}", value
       end
     end
   end

--- a/lib/twitch/user.rb
+++ b/lib/twitch/user.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Twitch
+  # Data object for Twitch users
   class User
     # ID of the user.
     attr_reader :id

--- a/lib/twitch/user.rb
+++ b/lib/twitch/user.rb
@@ -13,7 +13,7 @@ module Twitch
     # (global mod, admin, staff)
     attr_reader :type
     # Represents a special broadcaster role of a user.
-    # (partner, affilaite)
+    # (partner, affiliate)
     attr_reader :broadcaster_type
     # Description/biographical info of a user.
     attr_reader :description

--- a/lib/twitch/video.rb
+++ b/lib/twitch/video.rb
@@ -33,8 +33,7 @@ module Twitch
     attr_reader :user_name
     # Viewability of the video (public or private)
     attr_reader :viewable
-    # Duration of the video, in the format
-    # 0h0m0s
+    # Duration of the video, in the format `0h0m0s`
     attr_reader :duration
 
     def initialize(attributes = {})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+	"scripts": {
+		"remark": "remark ."
+	},
+	"devDependencies": {
+		"remark-cli": "^8.0.0",
+		"remark-lint-code-block-style": "^2.0.1",
+		"remark-preset-lint-recommended": "^4.0.0"
+	}
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,13 +13,9 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
-  end
-
-  VCR.configure do |c|
-    c.cassette_library_dir = 'spec/fixtures/cassettes'
-    c.filter_sensitive_data('<API KEY>') { ENV['TWITCH_CLIENT_ID'] }
-    c.hook_into :webmock
+  VCR.configure do |vcr_config|
+    vcr_config.cassette_library_dir = 'spec/fixtures/cassettes'
+    vcr_config.filter_sensitive_data('<API KEY>') { ENV['TWITCH_CLIENT_ID'] }
+    vcr_config.hook_into :webmock
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,15 @@
 
 require 'webmock/rspec'
 require 'vcr'
+
+require 'simplecov'
+SimpleCov.start
+
+if ENV['CODECOV_TOKEN']
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
+
 require_relative '../lib/twitch-api'
 
 ENV['TWITCH_CLIENT_ID'] ||= 'test'

--- a/spec/twitch/client_spec.rb
+++ b/spec/twitch/client_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Twitch::Client do
   end
 
   describe '#get_users' do
-    it 'can retrive a user by id' do
+    it 'can retrieve a user by id' do
       test_user_id = 18_587_270
 
       VCR.use_cassette('get_users_day9tv') do

--- a/spec/twitch_spec.rb
+++ b/spec/twitch_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe Twitch do
-  it 'has a version number' do
-    expect(Twitch::VERSION).not_to be nil
-  end
+RSpec.describe 'Twitch::VERSION' do
+  subject { Object.const_get(self.class.description) }
+
+  it { is_expected.to match(/^\d+\.\d+\.\d+$/) }
 end

--- a/twitch-api.gemspec
+++ b/twitch-api.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.91.0'
-  spec.add_development_dependency 'vcr', '~> 5.0'
+  spec.add_development_dependency 'vcr', '~> 6.0'
   spec.add_development_dependency 'webmock', '~> 3.1'
 end

--- a/twitch-api.gemspec
+++ b/twitch-api.gemspec
@@ -14,12 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4'
 
-  spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
+  spec.files = Dir['lib/**/*.rb', 'README.md', 'LICENSE.txt']
 
   spec.add_dependency 'faraday', '~> 1.0'
   spec.add_dependency 'faraday_middleware', '~> 1.0'

--- a/twitch-api.gemspec
+++ b/twitch-api.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/mauricew/ruby-twitch-api'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '~> 2.5'
 
   spec.files = Dir['lib/**/*.rb', 'README.md', 'LICENSE.txt']
 

--- a/twitch-api.gemspec
+++ b/twitch-api.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '>= 0.12.2'
-  spec.add_dependency 'faraday_middleware', '~> 0.12'
+  spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday_middleware', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/twitch-api.gemspec
+++ b/twitch-api.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/mauricew/ruby-twitch-api'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.80.0'
+  spec.add_development_dependency 'rubocop', '~> 0.91.0'
   spec.add_development_dependency 'vcr', '~> 5.0'
   spec.add_development_dependency 'webmock', '~> 3.1'
 end

--- a/twitch-api.gemspec
+++ b/twitch-api.gemspec
@@ -20,9 +20,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'codecov', '~> 0.2.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.91.0'
+  spec.add_development_dependency 'simplecov', '~> 0.19.0'
   spec.add_development_dependency 'vcr', '~> 6.0'
   spec.add_development_dependency 'webmock', '~> 3.1'
 end


### PR DESCRIPTION
*   Update Faraday to version 1.0
*   Update Travis CI config
*   Update RuboCop to version 0.91, fix all offenses
    *   Increase max line length from 80 to 100 (new RuboCop's default is 120).
    *   Increase required Ruby version from 2.3 to 2.4.
        Ruby 2.3 is no more supported and RuboCop drops its support too.
    *   Enable all new cops by default.
*   Improve `files` in gemspec and remove useless setters
*   Switch from Travis CI to Cirrus CI
*   Update VCR to new major version 6
*   Add link to LICENSE for its badge in README
*   Add `remark` lint (for Markdown) CI task
*   Improve code (style, variables names, duplication)
*   Fix small typos in documentation
*   Add SimpleCov and Codecov
*   Drop Ruby 2.4 support, SimpleCov requires 2.5
*   And it's not supported by core team:
    https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/