### PR TITLE
Make stream_id accessible in Video

### DIFF
--- a/lib/twitch/video.rb
+++ b/lib/twitch/video.rb
@@ -33,6 +33,8 @@ module Twitch
     attr_reader :viewable
     # Duration of the video, in the format `0h0m0s`
     attr_reader :duration
+    # ID of the original stream if the `type` is archive; nil otherwise
+    attr_reader :stream_id
 
     def initialize(attributes = {})
       attributes.each do |key, value|


### PR DESCRIPTION
Twitch's API reference shows that `stream_id` is an available field on the `get_videos` response - looks like this is already included in the cassettes, just not surfaced in the `Video` model:

https://dev.twitch.tv/docs/api/reference/#get-videos