### PR TITLE
Webhook support

### DIFF
--- a/lib/twitch-api.rb
+++ b/lib/twitch-api.rb
@@ -2,3 +2,6 @@
 
 require_relative 'twitch/version'
 require_relative 'twitch/client'
+require_relative 'twitch/webhook_config'
+require_relative 'twitch/webhook_event'
+require_relative 'twitch/webhook_handler'

--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -111,6 +111,7 @@ module Twitch
     include CustomRewards
 
     require_relative 'client/webhooks'
+    include Webhooks
 
     ## https://dev.twitch.tv/docs/api/reference#get-channel-information
     def get_channels(options = {})

--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -31,6 +31,7 @@ require_relative 'user_ban'
 require_relative 'user_follow'
 require_relative 'redemption'
 require_relative 'video'
+require_relative 'webhook_handler'
 
 module Twitch
   # Core class for requests
@@ -108,6 +109,8 @@ module Twitch
 
     require_relative 'client/custom_rewards'
     include CustomRewards
+
+    require_relative 'client/webhooks'
 
     ## https://dev.twitch.tv/docs/api/reference#get-channel-information
     def get_channels(options = {})

--- a/lib/twitch/client/webhooks.rb
+++ b/lib/twitch/client/webhooks.rb
@@ -5,10 +5,10 @@ module Twitch
     # Module for EventSub webhook functionality
     module Webhooks
       ## https://dev.twitch.tv/docs/api/reference#create-eventsub-subscription
-      def create_webhook_subscription(type:, condition:, callback_url:, secret:)
+      def create_webhook_subscription(type:, condition:, callback_url:, secret:, version: '1')
         initialize_response nil, post('eventsub/subscriptions', {
           type: type,
-          version: '1',
+          version: version,
           condition: condition,
           transport: {
             method: 'webhook',

--- a/lib/twitch/client/webhooks.rb
+++ b/lib/twitch/client/webhooks.rb
@@ -4,9 +4,15 @@ module Twitch
   class Client
     # Module for EventSub webhook functionality
     module Webhooks
-      ## https://dev.twitch.tv/docs/api/reference#create-eventsub-subscription
-      def create_webhook_subscription(type:, condition:, callback_url:, secret:, version: '1')
-        response = initialize_response nil, post('eventsub/subscriptions', {
+      # Create a new webhook subscription
+      # @param type [String] The subscription type (e.g., "channel.follow")
+      # @param version [String] The version of the subscription type
+      # @param condition [Hash] Subscription-specific parameters
+      # @param callback_url [String] URL where notifications will be sent
+      # @param secret [String] Secret used to verify webhook signatures
+      # @return [Twitch::Response] Response containing subscription details
+      def create_webhook_subscription(type:, condition:, callback_url:, secret:, version: 1)
+        initialize_response nil, post('eventsub/subscriptions', {
           type: type,
           version: version,
           condition: condition,
@@ -16,12 +22,12 @@ module Twitch
             secret: secret
           }
         })
-
-        puts response.data
-        puts response.raw
       end
 
-      ## https://dev.twitch.tv/docs/api/reference#get-eventsub-subscriptions
+      # Get list of webhook subscriptions
+      # @param status [String, nil] Filter by subscription status
+      # @param type [String, nil] Filter by subscription type
+      # @return [Twitch::Response] Response containing list of subscriptions
       def get_webhook_subscriptions(status: nil, type: nil)
         params = {}
         params[:status] = status if status
@@ -30,7 +36,9 @@ module Twitch
         initialize_response nil, get('eventsub/subscriptions', params)
       end
 
-      ## https://dev.twitch.tv/docs/api/reference#delete-eventsub-subscription
+      # Delete a webhook subscription
+      # @param id [String] ID of the subscription to delete
+      # @return [Twitch::Response] Empty response if successful
       def delete_webhook_subscription(id:)
         initialize_response nil, delete('eventsub/subscriptions', { id: id })
       end

--- a/lib/twitch/client/webhooks.rb
+++ b/lib/twitch/client/webhooks.rb
@@ -6,7 +6,7 @@ module Twitch
     module Webhooks
       ## https://dev.twitch.tv/docs/api/reference#create-eventsub-subscription
       def create_webhook_subscription(type:, condition:, callback_url:, secret:, version: '1')
-        initialize_response nil, post('eventsub/subscriptions', {
+        response = initialize_response nil, post('eventsub/subscriptions', {
           type: type,
           version: version,
           condition: condition,
@@ -16,6 +16,9 @@ module Twitch
             secret: secret
           }
         })
+
+        puts response.data
+        puts response.raw
       end
 
       ## https://dev.twitch.tv/docs/api/reference#get-eventsub-subscriptions

--- a/lib/twitch/client/webhooks.rb
+++ b/lib/twitch/client/webhooks.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Twitch
+  class Client
+    # Module for EventSub webhook functionality
+    module Webhooks
+      ## https://dev.twitch.tv/docs/api/reference#create-eventsub-subscription
+      def create_webhook_subscription(type:, condition:, callback_url:, secret:)
+        initialize_response nil, post('eventsub/subscriptions', {
+          type: type,
+          version: '1',
+          condition: condition,
+          transport: {
+            method: 'webhook',
+            callback: callback_url,
+            secret: secret
+          }
+        })
+      end
+
+      ## https://dev.twitch.tv/docs/api/reference#get-eventsub-subscriptions
+      def get_webhook_subscriptions(status: nil, type: nil)
+        params = {}
+        params[:status] = status if status
+        params[:type] = type if type
+
+        initialize_response nil, get('eventsub/subscriptions', params)
+      end
+
+      ## https://dev.twitch.tv/docs/api/reference#delete-eventsub-subscription
+      def delete_webhook_subscription(id:)
+        initialize_response nil, delete('eventsub/subscriptions', { id: id })
+      end
+    end
+
+    include Webhooks
+  end
+end

--- a/lib/twitch/webhook_config.rb
+++ b/lib/twitch/webhook_config.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Twitch
+  # Configuration class for Twitch webhooks
+  class WebhookConfig
+    class << self
+      attr_accessor :secret, :callback_url, :client, :logger
+
+      def configure
+        yield self
+      end
+
+      def setup_handlers(&on_setup)
+        # Allow application to do any necessary setup before registering handlers
+        on_setup&.call
+
+        # Setup handlers with client
+        WebhookHandler.setup_client(client, logger)
+      end
+
+      def log(message)
+        return unless logger
+
+        logger.info(message)
+      end
+
+      def log_error(message)
+        return unless logger
+
+        logger.error(message)
+      end
+    end
+  end
+end

--- a/lib/twitch/webhook_config.rb
+++ b/lib/twitch/webhook_config.rb
@@ -15,7 +15,7 @@ module Twitch
         on_setup&.call
 
         # Setup handlers with client
-        WebhookHandler.setup_client(client, logger)
+        WebhookHandler.setup_client(client)
       end
 
       def log(message)

--- a/lib/twitch/webhook_event.rb
+++ b/lib/twitch/webhook_event.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Twitch
+  # Represents a webhook event notification from Twitch
+  class WebhookEvent
+    # The subscription information
+    attr_reader :subscription
+    # The event data
+    attr_reader :event
+    # The timestamp of when the notification was sent
+    attr_reader :timestamp
+
+    def initialize(attributes = {})
+      @subscription = attributes['subscription']
+      @event = attributes['event']
+      @timestamp = Time.parse(attributes['timestamp']) if attributes['timestamp']
+    end
+
+    # The type of the event (e.g., "channel.follow")
+    def type
+      subscription['type']
+    end
+
+    # The version of the subscription
+    def version
+      subscription['version']
+    end
+
+    # The status of the subscription
+    def status
+      subscription['status']
+    end
+
+    # The condition parameters for this subscription
+    def condition
+      subscription['condition']
+    end
+
+    # Whether this is a revocation event
+    def revoked?
+      status == 'revoked'
+    end
+  end
+end

--- a/lib/twitch/webhook_handler.rb
+++ b/lib/twitch/webhook_handler.rb
@@ -24,10 +24,12 @@ module Twitch
 
     class_methods do
       def subscribe_to(type, version: '1', **condition)
+        stringified_condition = condition.transform_values(&:to_s)
+
         subscription_types << {
           type: type,
           version: version.to_s,
-          condition: condition
+          condition: stringified_condition
         }
       end
 

--- a/lib/twitch/webhook_handler.rb
+++ b/lib/twitch/webhook_handler.rb
@@ -24,17 +24,24 @@ module Twitch
 
     class_methods do
       def subscribe_to(type, version: '1', **condition)
-        stringified_condition = condition.transform_values(&:to_s)
+        transformed_condition = condition.transform_values do |value|
+          value.respond_to?(:call) ? value.call : value.to_s
+        end
 
         subscription_types << {
           type: type,
           version: version.to_s,
-          condition: stringified_condition
+          condition: transformed_condition
         }
       end
 
       def register_subscriptions(client)
         subscription_types.each do |subscription|
+          WebhookConfig.log('Processing subscription:')
+          WebhookConfig.log("Type: #{subscription[:type]}")
+          WebhookConfig.log("Version: #{subscription[:version]}")
+          WebhookConfig.log("Condition: #{subscription[:condition].inspect}")
+
           client.create_webhook_subscription(
             type: subscription[:type],
             version: subscription[:version],

--- a/lib/twitch/webhook_handler.rb
+++ b/lib/twitch/webhook_handler.rb
@@ -41,8 +41,19 @@ module Twitch
             callback_url: webhook_callback_url,
             secret: webhook_secret
           )
+
+          hash = {
+            type: subscription[:type],
+            version: subscription[:version],
+            condition: subscription[:condition],
+            callback_url: webhook_callback_url,
+            secret: webhook_secret
+          }
+
+          puts hash
         rescue Twitch::APIError => e
           Rails.logger.error "Failed to register webhook subscription: #{e.message}"
+          puts e
         end
       end
     end

--- a/lib/twitch/webhook_handler.rb
+++ b/lib/twitch/webhook_handler.rb
@@ -34,14 +34,6 @@ module Twitch
       # rubocop:disable Metrics/MethodLength
       def register_subscriptions(client)
         subscription_types.each do |subscription|
-          client.create_webhook_subscription(
-            type: subscription[:type],
-            version: subscription[:version],
-            condition: subscription[:condition],
-            callback_url: webhook_callback_url,
-            secret: webhook_secret
-          )
-
           hash = {
             type: subscription[:type],
             version: subscription[:version],
@@ -51,9 +43,16 @@ module Twitch
           }
 
           puts hash
+
+          client.create_webhook_subscription(
+            type: subscription[:type],
+            version: subscription[:version],
+            condition: subscription[:condition],
+            callback_url: webhook_callback_url,
+            secret: webhook_secret
+          )
         rescue Twitch::APIError => e
           Rails.logger.error "Failed to register webhook subscription: #{e.message}"
-          puts e
         end
       end
     end

--- a/lib/twitch/webhook_handler.rb
+++ b/lib/twitch/webhook_handler.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module Twitch
+  # Module for handling Twitch EventSub webhook notifications
+  module WebhookHandler
+    extend ActiveSupport::Concern
+
+    HMAC_PREFIX = 'sha256='
+    HEADER_MESSAGE_ID = 'twitch-eventsub-message-id'
+    HEADER_MESSAGE_TIMESTAMP = 'twitch-eventsub-message-timestamp'
+    HEADER_MESSAGE_SIGNATURE = 'twitch-eventsub-message-signature'
+    HEADER_MESSAGE_TYPE = 'twitch-eventsub-message-type'
+    HEADER_SUBSCRIPTION_TYPE = 'twitch-eventsub-subscription-type'
+
+    included do
+      before_action :verify_twitch_signature!
+      skip_before_action :verify_authenticity_token
+
+      class_attribute :subscription_types, default: []
+      class_attribute :twitch_client
+
+      Twitch::WebhookHandler.register_handler(self)
+    end
+
+    class_methods do
+      def subscribe_to(type, **condition)
+        subscription_types << {
+          type: type,
+          condition: condition
+        }
+      end
+
+      def register_subscriptions(client)
+        self.class.subscription_types.each do |subscription|
+          client.create_webhook_subscription(
+            type: subscription[:type],
+            condition: subscription[:condition],
+            callback_url: webhook_callback_url,
+            secret: webhook_secret
+          )
+        rescue Twitch::APIError => e
+          Rails.logger.error "Failed to register webhook subscription: #{e.message}"
+        end
+      end
+    end
+
+    class << self
+      def handlers
+        @handlers ||= []
+      end
+
+      def register_handler(handler_class)
+        handlers << handler_class
+        puts "Registered handler: #{handler_class}"
+      end
+
+      def setup_client(client)
+        puts "Setting up client for #{handlers.count} handlers"
+        handlers.each do |handler_class|
+          puts "Configuring handler: #{handler_class}"
+          handler_class.twitch_client = client
+          handler_class.register_subscriptions(client)
+        end
+      end
+    end
+
+    def receive
+      case request.headers[HEADER_MESSAGE_TYPE]&.downcase
+      when 'webhook_callback_verification'
+        handle_verification
+      when 'notification'
+        handle_notification
+      when 'revocation'
+        handle_revocation
+      else
+        head :no_content
+      end
+    end
+
+    private
+
+    def verify_twitch_signature!
+      message = build_hmac_message
+      hmac = "#{HMAC_PREFIX}#{generate_hmac(webhook_secret, message)}"
+      return if secure_compare(hmac, request.headers[HEADER_MESSAGE_SIGNATURE])
+
+      head :forbidden
+    end
+
+    def build_hmac_message
+      request.headers[HEADER_MESSAGE_ID] +
+        request.headers[HEADER_MESSAGE_TIMESTAMP] +
+        request.raw_post
+    end
+
+    def generate_hmac(secret, message)
+      OpenSSL::HMAC.hexdigest('sha256', secret, message)
+    end
+
+    def secure_compare(a, b)
+      return false unless b
+
+      ActiveSupport::SecurityUtils.secure_compare(a, b)
+    end
+
+    def handle_verification
+      render plain: JSON.parse(request.raw_post)['challenge']
+    end
+
+    def handle_notification
+      event_data = JSON.parse(request.raw_post)
+      event_type = request.headers[HEADER_SUBSCRIPTION_TYPE]
+
+      process_event(event_type, event_data)
+      head :no_content
+    end
+
+    def handle_revocation
+      event_data = JSON.parse(request.raw_post)
+      process_revocation(event_data)
+      head :no_content
+    end
+
+    def webhook_secret
+      raise NotImplementedError, 'Define webhook_secret in your controller'
+    end
+
+    def webhook_callback_url
+      raise NotImplementedError, 'Define webhook_callback_url in your controller'
+    end
+
+    def process_event(type, data)
+      raise NotImplementedError, 'Define process_event in your controller'
+    end
+
+    def process_revocation(data)
+      raise NotImplementedError, 'Define process_revocation in your controller'
+    end
+  end
+end

--- a/lib/twitch/webhook_handler.rb
+++ b/lib/twitch/webhook_handler.rb
@@ -23,17 +23,20 @@ module Twitch
     end
 
     class_methods do
-      def subscribe_to(type, **condition)
+      def subscribe_to(type, version: '1', **condition)
         subscription_types << {
           type: type,
+          version: version.to_s,
           condition: condition
         }
       end
 
+      # rubocop:disable Metrics/MethodLength
       def register_subscriptions(client)
-        self.class.subscription_types.each do |subscription|
+        subscription_types.each do |subscription|
           client.create_webhook_subscription(
             type: subscription[:type],
+            version: subscription[:version],
             condition: subscription[:condition],
             callback_url: webhook_callback_url,
             secret: webhook_secret


### PR DESCRIPTION
Hi :wave: 
I needed a Twitch EventSub for my Rails app, so I decided to add webhook support for this gem.
It needs much more work, but it works for my case already.

My controller looks something like [this](https://github.com/arthurka-o/ruby-twitch-api-webhook-example/blob/main/app/controllers/twitch_webhook_controller.rb) and initializer something like [this](https://github.com/arthurka-o/ruby-twitch-api-webhook-example/blob/main/config/initializers/twitch.rb)

It was my first time working on a Ruby gem (with a help of LLM), so there're probably (surely) some strange things.

From what I see already:
- I imported `ActiveSupport` for a webhook handler, not a very nice thing for a ruby gem not related to Rails.
- Tests
- Probably good thing would be adding all possible even types and their conditions with returning data schemes
- Squashing commits

I would need an advice of someone more experienced with Ruby gems to finish this